### PR TITLE
Parse comments in dependency lines

### DIFF
--- a/poetry_add_requirements_txt/utils.py
+++ b/poetry_add_requirements_txt/utils.py
@@ -4,4 +4,6 @@
 def preprocess_line(line: str) -> str:
     if line.startswith("#"):
         return ""
+    if "#" in line:
+        line, *_ = line.split("#")
     return line.strip()


### PR DESCRIPTION
Some requirements.txt have lines with comments like:

```
foo==3.0 # Install foo for reasons
```

This PR removes trailing comments if present.

